### PR TITLE
Remove leading character causing Django warning

### DIFF
--- a/drfx/urls.py
+++ b/drfx/urls.py
@@ -5,5 +5,5 @@ from django.urls import include, path
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include('api.urls')),
-    path('^api-auth/', include('rest_framework.urls')),
+    path('api-auth/', include('rest_framework.urls')),
 ]


### PR DESCRIPTION
The `^` character was causing the following warning from Django's check system:
>(2_0.W001) Your URL pattern '^api-auth/' has a route that contains '(?P<', begins with a '^', or ends with a '$'. This was likely an oversight when migrating to django.urls.path()