### PR TITLE
Add ''allauth.socialaccount' to installed applications

### DIFF
--- a/drfx/settings.py
+++ b/drfx/settings.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'allauth',
     'allauth.account',
+    'allauth.socialaccount',
     'rest_auth.registration',
 
     'api',


### PR DESCRIPTION
This allows users to be deleted out-of-the-box. See also: https://github.com/Tivix/django-rest-auth/issues/412