### PR TITLE
Staring minor versions of the packages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,10 +6,10 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-django = "==3.0.4"
-djangorestframework = "==3.11.0"
-django-rest-auth = "==0.9.5"
-django-allauth = "==0.41.0"
+django = "==3.0.*"
+djangorestframework = "==3.11.*"
+django-rest-auth = "==0.9.*"
+django-allauth = "==0.41.*"
 
 [requires]
 python_version = "3.7"


### PR DESCRIPTION
Good day!

Is the idea of starring minor versions of the packages is a good one? 

This should not break dependencies and even make it more secure. 

Thank you!